### PR TITLE
feat(docs): add comprehensive documentation using TypeDoc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,93 @@
+**Demo Dashboard Documentation v0.1.0**
+
+***
+
+# Demo Dashboard
+
+This is a dashboard application built with [Next.js](https://nextjs.org/) to monitor and display data from sensor devices. The application allows users to view real-time data and historical data in an intuitive way.
+
+## Key Features
+
+- **Device Selection**: Allows users to select a specific device to view its data.
+- **Latest Data Display**: Shows the most recent update from the selected device, including the data capture time.
+- **Historical Data Chart**: Presents historical data (Temperature, Humidity, Resistance) as a line chart, making it easy to track trends.
+- **Historical Data Table**: Provides a detailed table listing the recorded data history.
+- **Responsive User Interface**: Designed to work well on various screen sizes.
+
+## Folder Structure
+```plaintext
+/demo-dashboard/
+├── .gitignore               # Specifies intentionally untracked files that Git should ignore
+├── README.md                # This file, providing an overview of the project
+├── capacitor.config.ts      # Configuration for Capacitor (if used for native mobile apps)
+├── components.json          # Configuration for UI components (e.g., shadcn/ui)
+├── eslint.config.mjs        # ESLint configuration for code linting
+├── next.config.ts           # Next.js configuration file
+├── ormconfig.ts             # Configuration for TypeORM (if used)
+├── package-lock.json        # Records the exact versions of dependencies
+├── package.json             # Lists project dependencies and scripts
+├── patches/                 # Directory for patch files (e.g., for patch-package )
+│   └── lodash+3.10.1.patch
+├── postcss.config.mjs       # PostCSS configuration for CSS transformations
+├── public/                  # Static assets that are served directly
+│   ├── file.svg
+│   ├── globe.svg
+│   ├── next.svg
+│   ├── vercel.svg
+│   ├── window.svg
+│   └── workers/             # Directory for web workers
+│       └── autoUpdateWorker.js
+├── src/                     # Main source code directory
+│   ├── app/                 # Next.js App Router directory
+│   │   ├── api/             # API route handlers
+│   │   ├── favicon.ico      # Favicon for the application
+│   │   ├── globals.css      # Global CSS styles
+│   │   ├── layout.tsx       # Root layout component
+│   │   └── page.tsx         # Main page component for the root route
+│   ├── components/          # Reusable UI components
+│   │   └── ui/              # Sub-directory for UI-specific components (e.g., from a library)
+│   ├── entity/              # Database entity definitions (e.g., for TypeORM)
+│   │   └── Corrosion.ts
+│   ├── lib/                 # Utility functions and libraries
+│   │   └── utils.ts
+│   ├── types/               # TypeScript type definitions
+│   │   └── type.ts
+│   └── utils/               # General utility functions
+│       └── utils.ts
+└── tsconfig.json            # TypeScript configuration file
+```
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```
+To build the project for production:
+```bash
+npm run build
+# or
+yarn build
+# or
+pnpm build
+# or
+bun build
+```
+
+## Environment Variables
+To run this application, you need to set up the following environment variables in a .env file at the root of your project:
+
+```plaintext
+DB_HOST=your_database_host
+DB_USER=your_database_user
+DB_PASSWORD=your_database_password
+DB_NAME=your_database_name
+```
+These variables are crucial for the application to connect to the database and function correctly.

--- a/docs/app/api/data_history/[deviceId]/route/README.md
+++ b/docs/app/api/data_history/[deviceId]/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../modules.md) / app/api/data\_history/\[deviceId\]/route
+
+# app/api/data\_history/\[deviceId\]/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/data_history/[deviceId]/route/functions/GET.md
+++ b/docs/app/api/data_history/[deviceId]/route/functions/GET.md
@@ -1,0 +1,130 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../modules.md) / [app/api/data\_history/\[deviceId\]/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`, `context`): `Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<\{ `currentPage`: `number`; `data`: `object`[]; `limit`: `number`; `totalItems`: `number`; `totalPages`: `number`; \}\>\>
+
+Defined in: [src/app/api/data\_history/\[deviceId\]/route.ts:110](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/data_history/[deviceId]/route.ts#L110)
+
+## Parameters
+
+### request
+
+`NextRequest`
+
+### context
+
+#### params
+
+`Promise`\<\{ `deviceId`: `string`; \}\>
+
+## Returns
+
+`Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<\{ `currentPage`: `number`; `data`: `object`[]; `limit`: `number`; `totalItems`: `number`; `totalPages`: `number`; \}\>\>
+
+## Swagger
+
+/api/data_history/{deviceId}:
+  get:
+    summary: Retrieve historical corrosion data for a specific device with pagination.
+    description: Fetches a paginated list of historical corrosion data (temperature, humidity, resistor, and calendar date) for a given device ID.
+    tags:
+      - Data History
+    parameters:
+      - in: path
+        name: deviceId
+        required: true
+        description: The ID of the device to fetch data for.
+        schema:
+          type: string
+      - in: query
+        name: page
+        required: false
+        description: The page number for pagination (default is 1).
+        schema:
+          type: integer
+          default: 1
+      - in: query
+        name: limit
+        required: false
+        description: The number of items per page (default is 5).
+        schema:
+          type: integer
+          default: 5
+    responses:
+      200:
+        description: A list of historical corrosion data for the device.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ID:
+                        type: integer
+                        example: 1
+                      TEMPERATURE:
+                        type: number
+                        format: float
+                        example: 25.5
+                      HUMIDITY:
+                        type: number
+                        format: float
+                        example: 60.2
+                      RESISTOR:
+                        type: number
+                        format: float
+                        example: 1000.0
+                      CALENDAR:
+                        type: string
+                        example: "2023-10-27 10:30:00"
+                totalItems:
+                  type: integer
+                  example: 100
+                totalPages:
+                  type: integer
+                  example: 20
+                currentPage:
+                  type: integer
+                  example: 1
+                limit:
+                  type: integer
+                  example: 5
+      400:
+        description: Bad Request - Device ID is required.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Device ID is required"
+      404:
+        description: Not Found - No data found for the specified device ID.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "No temperature data found for device {deviceId}"
+      500:
+        description: Internal Server Error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Internal server error"

--- a/docs/app/api/devices/route/README.md
+++ b/docs/app/api/devices/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / app/api/devices/route
+
+# app/api/devices/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/devices/route/functions/GET.md
+++ b/docs/app/api/devices/route/functions/GET.md
@@ -1,0 +1,56 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../modules.md) / [app/api/devices/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`): `Promise`\<`NextResponse`\<\{ `devices`: `any`[]; \}\> \| `NextResponse`\<\{ `error`: `string`; `message`: `string`; \}\>\>
+
+Defined in: [src/app/api/devices/route.ts:40](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/devices/route.ts#L40)
+
+## Parameters
+
+### request
+
+`Request`
+
+## Returns
+
+`Promise`\<`NextResponse`\<\{ `devices`: `any`[]; \}\> \| `NextResponse`\<\{ `error`: `string`; `message`: `string`; \}\>\>
+
+## Swagger
+
+/api/devices:
+  get:
+    summary: Retrieve a list of distinct device IDs.
+    description: Fetches all unique device IDs from the corrosion data.
+    tags:
+      - Devices
+    responses:
+      200:
+        description: A list of distinct device IDs.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                devices:
+                  type: array
+                  items:
+                    type: integer
+                    example: 1
+      500:
+        description: Internal Server Error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Failed to fetch devices"
+                error:
+                  type: string
+                  example: "An unknown error occurred"

--- a/docs/app/api/humidity/[deviceId]/latest/route/README.md
+++ b/docs/app/api/humidity/[deviceId]/latest/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../modules.md) / app/api/humidity/\[deviceId\]/latest/route
+
+# app/api/humidity/\[deviceId\]/latest/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/humidity/[deviceId]/latest/route/functions/GET.md
+++ b/docs/app/api/humidity/[deviceId]/latest/route/functions/GET.md
@@ -1,0 +1,94 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../../modules.md) / [app/api/humidity/\[deviceId\]/latest/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`, `__namedParameters`): `Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\>\>
+
+Defined in: [src/app/api/humidity/\[deviceId\]/latest/route.ts:74](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/humidity/[deviceId]/latest/route.ts#L74)
+
+## Parameters
+
+### request
+
+`NextRequest`
+
+### \_\_namedParameters
+
+#### params
+
+`Promise`\<\{ `deviceId`: `string`; \}\>
+
+## Returns
+
+`Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\>\>
+
+## Swagger
+
+/api/humidity/{deviceId}/latest:
+  get:
+    summary: Retrieve the latest humidity data for a specific device.
+    tags:
+      - Humidity
+    parameters:
+      - in: path
+        name: deviceId
+        schema:
+          type: string
+        required: true
+        description: The ID of the device to fetch humidity data for.
+    responses:
+      200:
+        description: Successfully retrieved the latest humidity data.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  VALUE:
+                    type: number
+                    description: The humidity value.
+                  CALENDAR:
+                    type: string
+                    format: date-time
+                    description: The timestamp of the data recording.
+              example:
+                - VALUE: 75.2
+                  CALENDAR: "2023-10-27 10:30:00"
+                - VALUE: 74.8
+                  CALENDAR: "2023-10-27 10:25:00"
+      400:
+        description: Invalid request. Device ID is required.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Device ID is required"
+      404:
+        description: No humidity data found for the specified device.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "No humidity data found for device 123"
+      500:
+        description: Internal server error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Internal server error"

--- a/docs/app/api/latest_data/[deviceId]/route/README.md
+++ b/docs/app/api/latest_data/[deviceId]/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../modules.md) / app/api/latest\_data/\[deviceId\]/route
+
+# app/api/latest\_data/\[deviceId\]/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/latest_data/[deviceId]/route/functions/GET.md
+++ b/docs/app/api/latest_data/[deviceId]/route/functions/GET.md
@@ -1,0 +1,105 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../modules.md) / [app/api/latest\_data/\[deviceId\]/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`, `__namedParameters`): `Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<\{ `CALENDAR`: `string`; `DEVICE`: `number`; `HUMIDITY`: `number`; `RESISTOR`: `number`; `TEMPERATURE`: `number`; \}\>\>
+
+Defined in: [src/app/api/latest\_data/\[deviceId\]/route.ts:91](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/latest_data/[deviceId]/route.ts#L91)
+
+## Parameters
+
+### request
+
+`Request`
+
+### \_\_namedParameters
+
+#### params
+
+`Promise`\<\{ `deviceId`: `string`; \}\>
+
+## Returns
+
+`Promise`\<`NextResponse`\<\{ `message`: `string`; \}\> \| `NextResponse`\<\{ `CALENDAR`: `string`; `DEVICE`: `number`; `HUMIDITY`: `number`; `RESISTOR`: `number`; `TEMPERATURE`: `number`; \}\>\>
+
+## Swagger
+
+/api/latest_data/{deviceId}:
+  get:
+    summary: Retrieve the latest corrosion data for a specific device.
+    tags:
+      - Latest Data
+    parameters:
+      - in: path
+        name: deviceId
+        schema:
+          type: string
+        required: true
+        description: The ID of the device to fetch the latest data for.
+    responses:
+      200:
+        description: Successfully retrieved the latest device data.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                DEVICE:
+                  type: number
+                  description: The device ID.
+                HUMIDITY:
+                  type: number
+                  description: The latest humidity reading.
+                TEMPERATURE:
+                  type: number
+                  description: The latest temperature reading.
+                RESISTOR:
+                  type: number
+                  description: The latest resistor reading.
+                CALENDAR:
+                  type: string
+                  format: date-time
+                  description: The timestamp of the latest data recording.
+              example:
+                DEVICE: 123
+                HUMIDITY: 75.2
+                TEMPERATURE: 25.5
+                RESISTOR: 1000
+                CALENDAR: "2023-10-27 10:30:00"
+      400:
+        description: Invalid request. Device ID is required or invalid format.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Device ID is required" or "Invalid Device ID format"
+      404:
+        description: No data found for the specified device.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "No data found for this device"
+      500:
+        description: Internal server error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Failed to fetch data"
+                error:
+                  type: string
+                  example: "An unknown error occurred"

--- a/docs/app/api/resistor/[deviceId]/latest/route/README.md
+++ b/docs/app/api/resistor/[deviceId]/latest/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../modules.md) / app/api/resistor/\[deviceId\]/latest/route
+
+# app/api/resistor/\[deviceId\]/latest/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/resistor/[deviceId]/latest/route/functions/GET.md
+++ b/docs/app/api/resistor/[deviceId]/latest/route/functions/GET.md
@@ -1,0 +1,94 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../../modules.md) / [app/api/resistor/\[deviceId\]/latest/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`, `__namedParameters`): `Promise`\<`NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\> \| `NextResponse`\<\{ `message`: `string`; \}\>\>
+
+Defined in: [src/app/api/resistor/\[deviceId\]/latest/route.ts:75](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/resistor/[deviceId]/latest/route.ts#L75)
+
+## Parameters
+
+### request
+
+`NextRequest`
+
+### \_\_namedParameters
+
+#### params
+
+`Promise`\<\{ `deviceId`: `string`; \}\>
+
+## Returns
+
+`Promise`\<`NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\> \| `NextResponse`\<\{ `message`: `string`; \}\>\>
+
+## Swagger
+
+/api/resistor/{deviceId}/latest:
+  get:
+    summary: Retrieve the latest resistor data for a specific device.
+    tags:
+      - Resistor
+    parameters:
+      - in: path
+        name: deviceId
+        schema:
+          type: string
+        required: true
+        description: The ID of the device to fetch resistor data for.
+    responses:
+      200:
+        description: Successfully retrieved the latest resistor data.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  VALUE:
+                    type: number
+                    description: The resistor value.
+                  CALENDAR:
+                    type: string
+                    format: date-time
+                    description: The timestamp of the data recording.
+              example:
+                - VALUE: 1024
+                  CALENDAR: "2023-10-27 10:30:00"
+                - VALUE: 1020
+                  CALENDAR: "2023-10-27 10:25:00"
+      400:
+        description: Invalid request. Device ID is required or invalid format.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Device ID is required" or "Invalid Device ID format"
+      404:
+        description: No resistor data found for the specified device.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "No resistor data found for device 123"
+      500:
+        description: Internal server error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Internal server error"

--- a/docs/app/api/temperature/[deviceId]/latest/route/README.md
+++ b/docs/app/api/temperature/[deviceId]/latest/route/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../modules.md) / app/api/temperature/\[deviceId\]/latest/route
+
+# app/api/temperature/\[deviceId\]/latest/route
+
+## Functions
+
+- [GET](functions/GET.md)

--- a/docs/app/api/temperature/[deviceId]/latest/route/functions/GET.md
+++ b/docs/app/api/temperature/[deviceId]/latest/route/functions/GET.md
@@ -1,0 +1,94 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../../../../modules.md) / [app/api/temperature/\[deviceId\]/latest/route](../README.md) / GET
+
+# Function: GET()
+
+> **GET**(`request`, `__namedParameters`): `Promise`\<`NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\> \| `NextResponse`\<\{ `message`: `string`; \}\>\>
+
+Defined in: [src/app/api/temperature/\[deviceId\]/latest/route.ts:74](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/api/temperature/[deviceId]/latest/route.ts#L74)
+
+## Parameters
+
+### request
+
+`NextRequest`
+
+### \_\_namedParameters
+
+#### params
+
+`Promise`\<\{ `deviceId`: `string`; \}\>
+
+## Returns
+
+`Promise`\<`NextResponse`\<[`DataRecord`](../../../../../../../types/type/interfaces/DataRecord.md)[]\> \| `NextResponse`\<\{ `message`: `string`; \}\>\>
+
+## Swagger
+
+/api/temperature/{deviceId}/latest:
+  get:
+    summary: Retrieve the latest temperature data for a specific device.
+    tags:
+      - Temperature
+    parameters:
+      - in: path
+        name: deviceId
+        schema:
+          type: string
+        required: true
+        description: The ID of the device to fetch temperature data for.
+    responses:
+      200:
+        description: Successfully retrieved the latest temperature data.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  VALUE:
+                    type: number
+                    description: The temperature value.
+                  CALENDAR:
+                    type: string
+                    format: date-time
+                    description: The timestamp of the data recording.
+              example:
+                - VALUE: 25.5
+                  CALENDAR: "2023-10-27 10:30:00"
+                - VALUE: 25.0
+                  CALENDAR: "2023-10-27 10:25:00"
+      400:
+        description: Invalid request. Device ID is required.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Device ID is required"
+      404:
+        description: No temperature data found for the specified device.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "No temperature data found for device 123"
+      500:
+        description: Internal server error.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Internal server error"

--- a/docs/app/layout/README.md
+++ b/docs/app/layout/README.md
@@ -1,0 +1,15 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / app/layout
+
+# app/layout
+
+## Variables
+
+- [metadata](variables/metadata.md)
+
+## Functions
+
+- [default](functions/default.md)

--- a/docs/app/layout/functions/default.md
+++ b/docs/app/layout/functions/default.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [app/layout](../README.md) / default
+
+# Function: default()
+
+> **default**(`__namedParameters`): `Element`
+
+Defined in: [src/app/layout.tsx:11](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/layout.tsx#L11)
+
+## Parameters
+
+### \_\_namedParameters
+
+`Readonly`\<\{ `children`: `React.ReactNode`; \}\>
+
+## Returns
+
+`Element`

--- a/docs/app/layout/variables/metadata.md
+++ b/docs/app/layout/variables/metadata.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [app/layout](../README.md) / metadata
+
+# Variable: metadata
+
+> `const` **metadata**: `Metadata`
+
+Defined in: [src/app/layout.tsx:6](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/layout.tsx#L6)

--- a/docs/app/page/README.md
+++ b/docs/app/page/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / app/page
+
+# app/page
+
+## Functions
+
+- [default](functions/default.md)

--- a/docs/app/page/functions/default.md
+++ b/docs/app/page/functions/default.md
@@ -1,0 +1,24 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [app/page](../README.md) / default
+
+# Function: default()
+
+> **default**(): `Element`
+
+Defined in: [src/app/page.tsx:12](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/app/page.tsx#L12)
+
+## Returns
+
+`Element`
+
+## File
+
+Home page component for the dashboard.
+
+## Description
+
+This component serves as the main page of the application.
+It allows users to select a device and view its latest data, historical data in a graph, and a data table.

--- a/docs/components/ui/DataHistory/README.md
+++ b/docs/components/ui/DataHistory/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / components/ui/DataHistory
+
+# components/ui/DataHistory
+
+## Functions
+
+- [default](functions/default.md)

--- a/docs/components/ui/DataHistory/functions/default.md
+++ b/docs/components/ui/DataHistory/functions/default.md
@@ -1,0 +1,33 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/DataHistory](../README.md) / default
+
+# Function: default()
+
+> **default**(`props`): `Element`
+
+Defined in: [src/components/ui/DataHistory.tsx:26](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/DataHistory.tsx#L26)
+
+## Parameters
+
+### props
+
+`DataHistoryProps`
+
+The props for the component.
+
+## Returns
+
+`Element`
+
+The JSX element containing the data table and pagination controls.
+
+## Component
+
+DataHistory
+
+## Description
+
+Displays a paginated table of historical sensor data for a given device.

--- a/docs/components/ui/Graph/README.md
+++ b/docs/components/ui/Graph/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / components/ui/Graph
+
+# components/ui/Graph
+
+## Functions
+
+- [default](functions/default.md)

--- a/docs/components/ui/Graph/functions/default.md
+++ b/docs/components/ui/Graph/functions/default.md
@@ -1,0 +1,34 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/Graph](../README.md) / default
+
+# Function: default()
+
+> **default**(`props`): `Element`
+
+Defined in: [src/components/ui/Graph.tsx:46](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/Graph.tsx#L46)
+
+## Parameters
+
+### props
+
+`GraphProps`
+
+The props for the component.
+
+## Returns
+
+`Element`
+
+The JSX element containing the graph and data type selection.
+
+## Component
+
+Graph
+
+## Description
+
+Renders a line chart displaying historical sensor data (temperature, humidity, or resistor) for a selected device.
+Users can switch between different data types to visualize.

--- a/docs/components/ui/LastestData/README.md
+++ b/docs/components/ui/LastestData/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / components/ui/LastestData
+
+# components/ui/LastestData
+
+## Functions
+
+- [default](functions/default.md)

--- a/docs/components/ui/LastestData/functions/default.md
+++ b/docs/components/ui/LastestData/functions/default.md
@@ -1,0 +1,34 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/LastestData](../README.md) / default
+
+# Function: default()
+
+> **default**(`props`): `Element`
+
+Defined in: [src/components/ui/LastestData.tsx:16](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/LastestData.tsx#L16)
+
+## Parameters
+
+### props
+
+`LatestDataProps`
+
+The props for the component.
+
+## Returns
+
+`Element`
+
+The JSX element displaying the latest data.
+
+## Component
+
+LastestData
+
+## Description
+
+Displays the latest sensor data (temperature, humidity, resistor) for a given device.
+It fetches the data initially and then uses a Web Worker to receive real-time updates.

--- a/docs/components/ui/button/README.md
+++ b/docs/components/ui/button/README.md
@@ -1,0 +1,15 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / components/ui/button
+
+# components/ui/button
+
+## Variables
+
+- [buttonVariants](variables/buttonVariants.md)
+
+## Functions
+
+- [Button](functions/Button.md)

--- a/docs/components/ui/button/functions/Button.md
+++ b/docs/components/ui/button/functions/Button.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/button](../README.md) / Button
+
+# Function: Button()
+
+> **Button**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/button.tsx:38](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/button.tsx#L38)
+
+## Parameters
+
+### \_\_namedParameters
+
+`ClassAttributes`\<`HTMLButtonElement`\> & `ButtonHTMLAttributes`\<`HTMLButtonElement`\> & `VariantProps`\<(`props?`) => `string`\> & `object`
+
+## Returns
+
+`Element`

--- a/docs/components/ui/button/variables/buttonVariants.md
+++ b/docs/components/ui/button/variables/buttonVariants.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/button](../README.md) / buttonVariants
+
+# Variable: buttonVariants()
+
+> `const` **buttonVariants**: (`props?`) => `string`
+
+Defined in: [src/components/ui/button.tsx:7](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/button.tsx#L7)
+
+## Parameters
+
+### props?
+
+ConfigVariants\<\{ variant: \{ default: string; destructive: string; outline: string; secondary: string; ghost: string; link: string; \}; size: \{ default: string; sm: string; lg: string; icon: string; \}; \}\> & ClassProp
+
+## Returns
+
+`string`

--- a/docs/components/ui/pagination/README.md
+++ b/docs/components/ui/pagination/README.md
@@ -1,0 +1,17 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / components/ui/pagination
+
+# components/ui/pagination
+
+## Functions
+
+- [Pagination](functions/Pagination.md)
+- [PaginationContent](functions/PaginationContent.md)
+- [PaginationEllipsis](functions/PaginationEllipsis.md)
+- [PaginationItem](functions/PaginationItem.md)
+- [PaginationLink](functions/PaginationLink.md)
+- [PaginationNext](functions/PaginationNext.md)
+- [PaginationPrevious](functions/PaginationPrevious.md)

--- a/docs/components/ui/pagination/functions/Pagination.md
+++ b/docs/components/ui/pagination/functions/Pagination.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / Pagination
+
+# Function: Pagination()
+
+> **Pagination**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:11](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L11)
+
+## Parameters
+
+### \_\_namedParameters
+
+`DetailedHTMLProps`\<`HTMLAttributes`\<`HTMLElement`\>\>
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationContent.md
+++ b/docs/components/ui/pagination/functions/PaginationContent.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationContent
+
+# Function: PaginationContent()
+
+> **PaginationContent**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:23](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L23)
+
+## Parameters
+
+### \_\_namedParameters
+
+`DetailedHTMLProps`\<`HTMLAttributes`\<`HTMLUListElement`\>\>
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationEllipsis.md
+++ b/docs/components/ui/pagination/functions/PaginationEllipsis.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationEllipsis
+
+# Function: PaginationEllipsis()
+
+> **PaginationEllipsis**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:102](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L102)
+
+## Parameters
+
+### \_\_namedParameters
+
+`DetailedHTMLProps`\<`HTMLAttributes`\<`HTMLSpanElement`\>\>
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationItem.md
+++ b/docs/components/ui/pagination/functions/PaginationItem.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationItem
+
+# Function: PaginationItem()
+
+> **PaginationItem**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:36](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L36)
+
+## Parameters
+
+### \_\_namedParameters
+
+`DetailedHTMLProps`\<`LiHTMLAttributes`\<`HTMLLIElement`\>\>
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationLink.md
+++ b/docs/components/ui/pagination/functions/PaginationLink.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationLink
+
+# Function: PaginationLink()
+
+> **PaginationLink**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:45](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L45)
+
+## Parameters
+
+### \_\_namedParameters
+
+`PaginationLinkProps`
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationNext.md
+++ b/docs/components/ui/pagination/functions/PaginationNext.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationNext
+
+# Function: PaginationNext()
+
+> **PaginationNext**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:85](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L85)
+
+## Parameters
+
+### \_\_namedParameters
+
+`object` & `Pick`\<`ClassAttributes`\<`HTMLButtonElement`\> & `ButtonHTMLAttributes`\<`HTMLButtonElement`\> & `VariantProps`\<(`props?`) => `string`\> & `object`, `"size"`\> & `ClassAttributes`\<`HTMLAnchorElement`\> & `AnchorHTMLAttributes`\<`HTMLAnchorElement`\>
+
+## Returns
+
+`Element`

--- a/docs/components/ui/pagination/functions/PaginationPrevious.md
+++ b/docs/components/ui/pagination/functions/PaginationPrevious.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../../modules.md) / [components/ui/pagination](../README.md) / PaginationPrevious
+
+# Function: PaginationPrevious()
+
+> **PaginationPrevious**(`__namedParameters`): `Element`
+
+Defined in: [src/components/ui/pagination.tsx:68](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/components/ui/pagination.tsx#L68)
+
+## Parameters
+
+### \_\_namedParameters
+
+`object` & `Pick`\<`ClassAttributes`\<`HTMLButtonElement`\> & `ButtonHTMLAttributes`\<`HTMLButtonElement`\> & `VariantProps`\<(`props?`) => `string`\> & `object`, `"size"`\> & `ClassAttributes`\<`HTMLAnchorElement`\> & `AnchorHTMLAttributes`\<`HTMLAnchorElement`\>
+
+## Returns
+
+`Element`

--- a/docs/entity/Corrosion/README.md
+++ b/docs/entity/Corrosion/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / entity/Corrosion
+
+# entity/Corrosion
+
+## Classes
+
+- [Corrosion](classes/Corrosion.md)

--- a/docs/entity/Corrosion/classes/Corrosion.md
+++ b/docs/entity/Corrosion/classes/Corrosion.md
@@ -1,0 +1,67 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [entity/Corrosion](../README.md) / Corrosion
+
+# Class: Corrosion
+
+Defined in: [src/entity/Corrosion.ts:4](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L4)
+
+## Constructors
+
+### Constructor
+
+> **new Corrosion**(): `Corrosion`
+
+#### Returns
+
+`Corrosion`
+
+## Properties
+
+### CALENDAR
+
+> **CALENDAR**: `Date`
+
+Defined in: [src/entity/Corrosion.ts:22](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L22)
+
+***
+
+### DEVICE
+
+> **DEVICE**: `number`
+
+Defined in: [src/entity/Corrosion.ts:9](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L9)
+
+***
+
+### HUMIDITY
+
+> **HUMIDITY**: `number`
+
+Defined in: [src/entity/Corrosion.ts:18](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L18)
+
+***
+
+### ID
+
+> **ID**: `number`
+
+Defined in: [src/entity/Corrosion.ts:6](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L6)
+
+***
+
+### RESISTOR
+
+> **RESISTOR**: `number`
+
+Defined in: [src/entity/Corrosion.ts:12](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L12)
+
+***
+
+### TEMPERATURE
+
+> **TEMPERATURE**: `number`
+
+Defined in: [src/entity/Corrosion.ts:15](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/entity/Corrosion.ts#L15)

--- a/docs/lib/utils/README.md
+++ b/docs/lib/utils/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / lib/utils
+
+# lib/utils
+
+## Functions
+
+- [cn](functions/cn.md)

--- a/docs/lib/utils/functions/cn.md
+++ b/docs/lib/utils/functions/cn.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [lib/utils](../README.md) / cn
+
+# Function: cn()
+
+> **cn**(...`inputs`): `string`
+
+Defined in: [src/lib/utils.ts:4](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/lib/utils.ts#L4)
+
+## Parameters
+
+### inputs
+
+...`ClassValue`[]
+
+## Returns
+
+`string`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,25 @@
+[**Demo Dashboard Documentation v0.1.0**](README.md)
+
+***
+
+# Demo Dashboard Documentation v0.1.0
+
+## Modules
+
+- [app/api/data\_history/\[deviceId\]/route](app/api/data_history/[deviceId]/route/README.md)
+- [app/api/devices/route](app/api/devices/route/README.md)
+- [app/api/humidity/\[deviceId\]/latest/route](app/api/humidity/[deviceId]/latest/route/README.md)
+- [app/api/latest\_data/\[deviceId\]/route](app/api/latest_data/[deviceId]/route/README.md)
+- [app/api/resistor/\[deviceId\]/latest/route](app/api/resistor/[deviceId]/latest/route/README.md)
+- [app/api/temperature/\[deviceId\]/latest/route](app/api/temperature/[deviceId]/latest/route/README.md)
+- [app/layout](app/layout/README.md)
+- [app/page](app/page/README.md)
+- [components/ui/button](components/ui/button/README.md)
+- [components/ui/DataHistory](components/ui/DataHistory/README.md)
+- [components/ui/Graph](components/ui/Graph/README.md)
+- [components/ui/LastestData](components/ui/LastestData/README.md)
+- [components/ui/pagination](components/ui/pagination/README.md)
+- [entity/Corrosion](entity/Corrosion/README.md)
+- [lib/utils](lib/utils/README.md)
+- [types/type](types/type/README.md)
+- [utils/utils](utils/utils/README.md)

--- a/docs/types/type/README.md
+++ b/docs/types/type/README.md
@@ -1,0 +1,17 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / types/type
+
+# types/type
+
+## Interfaces
+
+- [DataHistoryRecord](interfaces/DataHistoryRecord.md)
+- [DataRecord](interfaces/DataRecord.md)
+- [LatestCorrosionData](interfaces/LatestCorrosionData.md)
+
+## Type Aliases
+
+- [PlottableDataKey](type-aliases/PlottableDataKey.md)

--- a/docs/types/type/interfaces/DataHistoryRecord.md
+++ b/docs/types/type/interfaces/DataHistoryRecord.md
@@ -1,0 +1,49 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [types/type](../README.md) / DataHistoryRecord
+
+# Interface: DataHistoryRecord
+
+Defined in: [src/types/type.ts:6](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L6)
+
+## Properties
+
+### CALENDAR
+
+> **CALENDAR**: `string`
+
+Defined in: [src/types/type.ts:11](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L11)
+
+***
+
+### HUMIDITY
+
+> **HUMIDITY**: `number`
+
+Defined in: [src/types/type.ts:9](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L9)
+
+***
+
+### ID
+
+> **ID**: `number`
+
+Defined in: [src/types/type.ts:7](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L7)
+
+***
+
+### RESISTOR
+
+> **RESISTOR**: `number`
+
+Defined in: [src/types/type.ts:10](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L10)
+
+***
+
+### TEMPERATURE
+
+> **TEMPERATURE**: `number`
+
+Defined in: [src/types/type.ts:8](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L8)

--- a/docs/types/type/interfaces/DataRecord.md
+++ b/docs/types/type/interfaces/DataRecord.md
@@ -1,0 +1,25 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [types/type](../README.md) / DataRecord
+
+# Interface: DataRecord
+
+Defined in: [src/types/type.ts:1](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L1)
+
+## Properties
+
+### CALENDAR
+
+> **CALENDAR**: `string`
+
+Defined in: [src/types/type.ts:3](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L3)
+
+***
+
+### VALUE
+
+> **VALUE**: `number`
+
+Defined in: [src/types/type.ts:2](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L2)

--- a/docs/types/type/interfaces/LatestCorrosionData.md
+++ b/docs/types/type/interfaces/LatestCorrosionData.md
@@ -1,0 +1,49 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [types/type](../README.md) / LatestCorrosionData
+
+# Interface: LatestCorrosionData
+
+Defined in: [src/types/type.ts:14](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L14)
+
+## Properties
+
+### CALENDAR
+
+> **CALENDAR**: `string`
+
+Defined in: [src/types/type.ts:19](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L19)
+
+***
+
+### DEVICE
+
+> **DEVICE**: `string`
+
+Defined in: [src/types/type.ts:15](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L15)
+
+***
+
+### HUMIDITY
+
+> **HUMIDITY**: `number`
+
+Defined in: [src/types/type.ts:17](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L17)
+
+***
+
+### RESISTOR
+
+> **RESISTOR**: `number`
+
+Defined in: [src/types/type.ts:18](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L18)
+
+***
+
+### TEMPERATURE
+
+> **TEMPERATURE**: `number`
+
+Defined in: [src/types/type.ts:16](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L16)

--- a/docs/types/type/type-aliases/PlottableDataKey.md
+++ b/docs/types/type/type-aliases/PlottableDataKey.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [types/type](../README.md) / PlottableDataKey
+
+# Type Alias: PlottableDataKey
+
+> **PlottableDataKey** = `"TEMPERATURE"` \| `"HUMIDITY"` \| `"RESISTOR"`
+
+Defined in: [src/types/type.ts:22](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/types/type.ts#L22)

--- a/docs/utils/utils/README.md
+++ b/docs/utils/utils/README.md
@@ -1,0 +1,11 @@
+[**Demo Dashboard Documentation v0.1.0**](../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../modules.md) / utils/utils
+
+# utils/utils
+
+## Functions
+
+- [formatDateTime](functions/formatDateTime.md)

--- a/docs/utils/utils/functions/formatDateTime.md
+++ b/docs/utils/utils/functions/formatDateTime.md
@@ -1,0 +1,21 @@
+[**Demo Dashboard Documentation v0.1.0**](../../../README.md)
+
+***
+
+[Demo Dashboard Documentation](../../../modules.md) / [utils/utils](../README.md) / formatDateTime
+
+# Function: formatDateTime()
+
+> **formatDateTime**(`dateString`): `string`
+
+Defined in: [src/utils/utils.ts:1](https://github.com/quanggdungg0609/demo-dashboard/blob/b55cc6ef037a292ef4b8bf41b596e28cace15611/src/utils/utils.ts#L1)
+
+## Parameters
+
+### dateString
+
+`string`
+
+## Returns
+
+`string`

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "prisma": "^6.8.2",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.0",
+        "typedoc": "^0.28.5",
+        "typedoc-plugin-markdown": "^4.6.4",
         "typescript": "^5"
       }
     },
@@ -511,6 +513,20 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
+      "integrity": "sha512-3jXo5bNjvvimvdbIhKGfFxSnKCX+MA8wzHv55ptzk/cx8wOzT+BRcYgj8aFN3yTiTs+zvQQiaZFr7Jce1ZG3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.4.2",
+        "@shikijs/langs": "^3.4.2",
+        "@shikijs/themes": "^3.4.2",
+        "@shikijs/types": "^3.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1605,6 +1621,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.5.0.tgz",
+      "integrity": "sha512-DLM1VL+WvWFHQlikP8MTc8T2MdEGAOJhAi9+48wkQ7kO7c/99h4ALK0b0CPQBCeLMp37raoM1Ucuo3OTSjtUxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.5.0.tgz",
+      "integrity": "sha512-kBJhmj0ZkULbf3O+Asr8Xs7hcFtQdPnqIld2kKrG9WhDpIvqMRWSj3L9LECi2TH7vV6ROrvJ78/1yEASL0d00w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.5.0.tgz",
+      "integrity": "sha512-xr4bPmAORm2fhfVeaCDfRXiq0rxAxPRR0Bhiw+EaofgJ79Jj61fnVZDF40nJKvmMoKnC60TqCTpbr15ToTgTOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-VvqGHhS8BWClF7eVnEJLe0nAhQw/1L+xC5mp6uj+tVr3tjD2ASx2Mx9M9l7tZQO++1qwZeIIusvSRhz4aKODFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -2013,6 +2078,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2059,6 +2134,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4106,6 +4188,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6571,6 +6666,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -6681,6 +6786,13 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -6691,6 +6803,24 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6699,6 +6829,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -7588,6 +7725,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9181,6 +9328,69 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
+      "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.2",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.4.tgz",
+      "integrity": "sha512-AnbToFS1T1H+n40QbO2+i0wE6L+55rWnj7zxnM1r781+2gmhMF2dB6dzFpaylWLQYkbg4D1Y13sYnne/6qZwdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typeorm": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.24.tgz",
@@ -9300,6 +9510,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next export",
+    "docs": "typedoc --entryPointStrategy expand --entryPoints src --out docs"
   },
   "dependencies": {
     "@capacitor/cli": "^7.2.0",
@@ -40,6 +41,8 @@
     "prisma": "^6.8.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.0",
+    "typedoc": "^0.28.5",
+    "typedoc-plugin-markdown": "^4.6.4",
     "typescript": "^5"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+    "entryPoints": ["./src"],
+    "entryPointStrategy": "expand",
+    "out": "docs",
+    "exclude": [" /node_modules/ "],
+    "name": "Demo Dashboard Documentation",
+    "includeVersion": true,
+    "theme": "default",
+    "plugin": ["typedoc-plugin-markdown"]
+    }


### PR DESCRIPTION
Generate detailed API documentation for the entire codebase using TypeDoc with markdown plugin. The documentation includes:
- Module structure and component descriptions
- Type definitions and interfaces
- API endpoint documentation with Swagger-style specs
- Function and class documentation with parameters and return types

Added new npm scripts for documentation generation and updated package.json dependencies accordingly.